### PR TITLE
Remove trailing slash

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -53,7 +53,7 @@ export default {
     generate: {
         crawler: false,
         fallback: '404.html',
-        subFolders: true, // TODO: Set to false once Cf bug with period asset resolution is fixed
+        subFolders: false,
         routes: [
             ...jsonData('lists').map(list => `/lists/${list}`),
             ...jsonData('features').map(feature => `/features/${feature}`),
@@ -84,49 +84,49 @@ export default {
     },
     sitemap: {
         hostname: 'https://botblock.org',
-        routes: [ // TODO: Remove trailing slash once Cf bug with period asset resolution is fixed
+        routes: [
             {
-                url: '/',
+                url: '',
                 priority: 1,
             },
             {
-                url: '/docs/',
+                url: '/docs',
                 priority: 0.9,
             },
             {
-                url: '/docs/libraries/',
+                url: '/docs/libraries',
                 priority: 0.8,
             },
             {
-                url: '/lists/',
+                url: '/lists',
                 priority: 0.8,
             },
             {
-                url: '/features/',
+                url: '/features',
                 priority: 0.7,
             },
             ...jsonData('lists').map(list => ({
-                url: `/lists/${list}/`,
+                url: `/lists/${list}`,
                 priority: 0.6,
             })),
             {
-                url: '/lists/best-practices/',
+                url: '/lists/best-practices',
                 priority: 0.5,
             },
             {
-                url: '/about/',
+                url: '/about',
                 priority: 0.5,
             },
             ...jsonData('features').map(feature => ({
-                url: `/features/${feature}/`,
+                url: `/features/${feature}`,
                 priority: 0.4,
             })),
             {
-                url: '/lists/defunct/',
+                url: '/lists/defunct',
                 priority: 0.3,
             },
             {
-                url: '/lists/hidden/',
+                url: '/lists/hidden',
                 priority: 0.2,
             },
         ],

--- a/util/generateHead.js
+++ b/util/generateHead.js
@@ -22,8 +22,7 @@ export default (meta, context) => {
     const pageKeywords = contextKeywords.concat(defaultKeywords).join(', ');
 
     // Get base & page URL
-    // TODO: Remove trailing slash once Cf bug with period asset resolution is fixed
-    const pageUrl = `https://botblock.org${context.$route.path}/`;
+    const pageUrl = `https://botblock.org${context.$route.path}`;
 
     return {
         title: pageTitle,


### PR DESCRIPTION
Cloudflare has fixed asset routing, so no trailing slash is needed now